### PR TITLE
Adding a low-pass filter before downsample reduces aliasing quite dramatically

### DIFF
--- a/dsp/RecursiveLinearFilter.cpp
+++ b/dsp/RecursiveLinearFilter.cpp
@@ -162,3 +162,20 @@ void recursive_linear_filter::HighShelf::SetParams(const recursive_linear_filter
 
   this->_AssignCoefficients(a0, a1, a2, b0, b1, b2);
 }
+
+void recursive_linear_filter::LowPassBiquad::SetParams(const recursive_linear_filter::BiquadParams& params)
+{
+    const double omega0 = params.GetOmega0();
+    const double cosw0 = std::cos(omega0);
+    const double alpha = params.GetAlpha(omega0);
+
+    const double b0 = (1.0 - cosw0) / 2.0;
+    const double b1 = 1.0 - cosw0;
+    const double b2 = (1.0 - cosw0) / 2.0;
+    const double a0 = 1.0 + alpha;
+    const double a1 = -2.0 * cosw0;
+    const double a2 = 1.0 - alpha;
+
+    // Normalize the coefficients by a0 and assign them
+    this->_AssignCoefficients(a0, a1, a2, b0, b1, b2);
+}

--- a/dsp/RecursiveLinearFilter.h
+++ b/dsp/RecursiveLinearFilter.h
@@ -202,4 +202,11 @@ public:
   }
 };
 
+class LowPassBiquad : public Biquad
+{
+public:
+    LowPassBiquad() : Biquad() {}
+    void SetParams(const BiquadParams& params) override;
+};
+
 }; // namespace recursive_linear_filter

--- a/dsp/ResamplingContainer/ResamplingContainer.h
+++ b/dsp/ResamplingContainer/ResamplingContainer.h
@@ -192,12 +192,13 @@ public:
       {
         throw std::runtime_error("Got more encapsulated samples than the encapsulated DSP is prepared to handle!");
       }
-      mLowPassFilter.Process(mEncapsulatedOutputPointers.GetList(), 1, populated1);
 
-
+      
+      
       func(mEncapsulatedInputPointers.GetList(), mEncapsulatedOutputPointers.GetList(), (int)populated1);
+      DSP_SAMPLE** filteredOutputs = mLowPassFilter.Process(mEncapsulatedOutputPointers.GetList(), 1, populated1);
       // And push the results into the second resampler so that it has what the external context requires.
-      mResampler2->PushBlock(mEncapsulatedOutputPointers.GetList(), populated1);
+      mResampler2->PushBlock(filteredOutputs, populated1);
     }
 
     // Pop the required output from the second resampler for the external context.


### PR DESCRIPTION
This pull request fixes the aliasing by adding a simple low pass filter in the resample container just before downsampling.

The original resampling code did not have a lowpass filter before downsampling. This creates a lot of alias because the NAM block creates a lot of harmonic distortion, thus content above nyquist limit of the target signal.

For example, see here from up to down. 1) reaper 4x effects oversampling 2) original NAM 0.7.8 oversampline 
**3)** This PULL request: input signal 48k -> upsample 192k -> NAM 192k -> **lowpass 0.9*24k** -> downsample 48k. 

Could you include this in the 0.7.8 version of the plugin, it would greatly improve the alias behaviour when using NAM captures of higher sampling rates and input / output at lower sampling rates.

![Screenshot 2024-02-04 at 12 37 25](https://github.com/sdatkinson/AudioDSPTools/assets/2007263/12a7eb92-a944-4f16-a703-b6a777e47ac7)
