### PR TITLE
[BUGFIX] Ensure resampling container fills the output buffer.

### DIFF
--- a/dsp/ResamplingContainer/ResamplingContainer.h
+++ b/dsp/ResamplingContainer/ResamplingContainer.h
@@ -191,7 +191,14 @@ public:
     const auto populated2 = mResampler2->PopBlock(outputs, nFrames);
     if (populated2 < nFrames)
     {
-      throw std::runtime_error("Did not yield enough samples to provide the required output buffer!");
+      std::cerr << "Did not yield enough samples (" << populated2 << ") to provide the required output buffer (expected"
+                << nFrames << ")! Filling with last sample..." << std::endl;
+      for (int c = 0; c < NCHANS; c++) {
+        const T lastSample = populated2 > 0 ? outputs[c][populated2 - 1] : 0.0;
+          for (int i = populated2; i < nFrames; i++) {
+            outputs[c][i] = lastSample;
+        }
+      }
     }
     // Get ready for the next block:
     mResampler1->RenormalizePhases();


### PR DESCRIPTION
Hacky fix while use of rational numbers in phase calculations is being worked on.

Resolves #13 .

_But, there's a risk the other way that the latency will **grow** over time if the fp errors accumulate in the other direction!_