### PR TITLE
Fixed compiler errors that result from defining DSP_SAMPLE_FLOAT

### DIFF
--- a/dsp/ImpulseResponse.cpp
+++ b/dsp/ImpulseResponse.cpp
@@ -35,7 +35,7 @@ dsp::ImpulseResponse::ImpulseResponse(const IRData& irData, const double sampleR
   this->_SetWeights();
 }
 
-double** dsp::ImpulseResponse::Process(double** inputs, const size_t numChannels, const size_t numFrames)
+DSP_SAMPLE** dsp::ImpulseResponse::Process(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames)
 {
   this->_PrepareBuffers(numChannels, numFrames);
   this->_UpdateHistory(inputs, numChannels, numFrames);

--- a/dsp/ImpulseResponse.h
+++ b/dsp/ImpulseResponse.h
@@ -23,7 +23,7 @@ public:
   struct IRData;
   ImpulseResponse(const char* fileName, const double sampleRate);
   ImpulseResponse(const IRData& irData, const double sampleRate);
-  double** Process(double** inputs, const size_t numChannels, const size_t numFrames) override;
+  DSP_SAMPLE** Process(DSP_SAMPLE** inputs, const size_t numChannels, const size_t numFrames) override;
   IRData GetData();
   double GetSampleRate() const { return mSampleRate; };
   // TODO states for the IR class

--- a/dsp/NoiseGate.h
+++ b/dsp/NoiseGate.h
@@ -124,7 +124,7 @@ private:
 
   // Hold the vectors of gain reduction for the block, in dB.
   // These can be given to the Gain object.
-  std::vector<std::vector<double>> mGainReductionDB;
+  std::vector<std::vector<DSP_SAMPLE>> mGainReductionDB;
   std::vector<double> mLastGainReductionDB;
 
   double mSampleRate;

--- a/dsp/wav.cpp
+++ b/dsp/wav.cpp
@@ -16,6 +16,10 @@
 
 #include "wav.h"
 
+#ifdef __linux__
+#include <cstdint>
+#endif
+
 bool idIsNotJunk(char* id)
 {
   return strncmp(id, "RIFF", 4) == 0 || strncmp(id, "WAVE", 4) == 0 || strncmp(id, "fmt ", 4) == 0


### PR DESCRIPTION
This pull request addresses the compiler errors that result from using the `DSP_SAMPLE_FLOAT` definition.
Some of the dsp modules explicitly use the `double` keyword on template parameters, function argument, return types etc.

This becomes a problem when the `DSP_SAMPLE_FLOAT` macro is defined as some compilers complain about not being able to convert floats to doubles (which makes sense in some cases since float variables and pointers are being passed to function calls that are expecting doubles).

More specifically these errors occur for:

* The `IpulseResponse` class `Process` function expects and returns double pointers.

* The `mGainReductionDB` vector declaration in line 127 of `NoiseGate.h` in the `Trigger` class, has a template parameter of double while the `GetGainReduction()` function in line 93 is returning a vector of type `DSP_SAMPLE` which would be float in the case of the DSP_SAMPLE_FLOAT definition.

I'm not sure if there was a specific reason for the ImpulseResponse class to be explicitly using double precision when the other classes including the base DSP are using the macro, but this change shouldn't be too invasive since everything is defaulting to double.

I hope it's ok that I didn't open an issue first, I didn't think it was needed since the changes are pretty small...