### PR TITLE
Fix loading WAV files from Unicode paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 
 project(NAM VERSION 0.0.1)
 
+include(CTest)
+
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(CMAKE_CXX_STANDARD 20)

--- a/dsp/wav.cpp
+++ b/dsp/wav.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstring> // strncmp
 #include <cmath> // pow
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -341,7 +342,12 @@ dsp::wav::LoadReturnCode dsp::wav::Load(const char* fileName, std::vector<float>
 {
   // FYI: https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html
   // Open the WAV file for reading
-  std::ifstream wavFile(fileName, std::ios::binary);
+#ifdef __cpp_char8_t
+  const auto filePath = std::filesystem::path(reinterpret_cast<const char8_t*>(fileName));
+#else
+  const auto filePath = std::filesystem::u8path(fileName);
+#endif
+  std::ifstream wavFile(filePath, std::ios::binary);
 
   // Check if the file was opened successfully
   if (!wavFile.is_open())

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -11,6 +11,9 @@ include_directories(tools ${NAM_DEPS_PATH}/nlohmann)
 
 add_executable(loadmodel loadmodel.cpp ${AUDIO_DSP_TOOLS_SOURCES})
 add_executable(benchmodel benchmodel.cpp ${AUDIO_DSP_TOOLS_SOURCES})
+add_executable(test_wav test_wav.cpp ${AUDIO_DSP_TOOLS_SOURCES})
+
+add_test(NAME wav_unicode_path COMMAND test_wav)
 
 source_group(NAM ${CMAKE_CURRENT_SOURCE_DIR} FILES ${AUDIO_DSP_TOOLS_SOURCES})
 

--- a/tools/test_wav.cpp
+++ b/tools/test_wav.cpp
@@ -30,8 +30,8 @@ int main()
 
   // 16-bit, mono, 48 kHz PCM WAV containing one silent sample.
   constexpr std::array<unsigned char, 46> wavData{
-    'R', 'I', 'F', 'F', 38, 0, 0, 0, 'W', 'A', 'V', 'E', 'f', 'm', 't', ' ', 16, 0, 0, 0, 1, 0, 1,
-    0,   0x80, 0xBB, 0, 0, 0, 0x77, 1, 0, 2, 0, 16, 0, 'd', 'a', 't', 'a', 2, 0, 0, 0, 0, 0};
+    'R', 'I',  'F',  'F', 38, 0, 0,    0, 'W', 'A', 'V', 'E', 'f', 'm', 't', ' ', 16,  0, 0, 0, 1, 0, 1,
+    0,   0x80, 0xBB, 0,   0,  0, 0x77, 1, 0,   2,   0,   16,  0,   'd', 'a', 't', 'a', 2, 0, 0, 0, 0, 0};
 
   {
     std::ofstream wavFile(wavPath, std::ios::binary);

--- a/tools/test_wav.cpp
+++ b/tools/test_wav.cpp
@@ -1,0 +1,55 @@
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "dsp/wav.h"
+
+namespace
+{
+std::string ToUTF8(const std::filesystem::path& path)
+{
+  const auto utf8 = path.u8string();
+  return {utf8.begin(), utf8.end()};
+}
+} // namespace
+
+int main()
+{
+#ifdef _WIN32
+  const auto emojiDirectoryName = std::filesystem::path(L"nam-\U0001F3B8");
+#else
+  const auto emojiDirectoryName = std::filesystem::path("nam-\xF0\x9F\x8E\xB8");
+#endif
+  const auto testDirectory = std::filesystem::temp_directory_path() / emojiDirectoryName;
+  const auto wavPath = testDirectory / "ir.wav";
+
+  std::filesystem::create_directories(testDirectory);
+
+  // 16-bit, mono, 48 kHz PCM WAV containing one silent sample.
+  constexpr std::array<unsigned char, 46> wavData{
+    'R', 'I', 'F', 'F', 38, 0, 0, 0, 'W', 'A', 'V', 'E', 'f', 'm', 't', ' ', 16, 0, 0, 0, 1, 0, 1,
+    0,   0x80, 0xBB, 0, 0, 0, 0x77, 1, 0, 2, 0, 16, 0, 'd', 'a', 't', 'a', 2, 0, 0, 0, 0, 0};
+
+  {
+    std::ofstream wavFile(wavPath, std::ios::binary);
+    wavFile.write(reinterpret_cast<const char*>(wavData.data()), wavData.size());
+  }
+
+  std::vector<float> audio;
+  double sampleRate = 0.0;
+  const auto utf8Path = ToUTF8(wavPath);
+  const auto result = dsp::wav::Load(utf8Path.c_str(), audio, sampleRate);
+
+  std::filesystem::remove_all(testDirectory);
+
+  if (result != dsp::wav::LoadReturnCode::SUCCESS || audio.size() != 1 || sampleRate != 48000.0)
+  {
+    std::cerr << "Failed to load WAV from UTF-8 path" << std::endl;
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- open UTF-8 WAV filenames through a native `std::filesystem::path`
- add a regression test that loads a valid WAV from an emoji-named directory
- preserve C++17 and C++20 compatibility

## Tests
- `cmake --build build/issue-641 -j4`
- `ctest --test-dir build/issue-641 --output-on-failure`
- direct C++17 build and execution of `test_wav`

Supports sdatkinson/NeuralAmpModelerPlugin#641.
